### PR TITLE
Updating name change to windows guide

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -145,7 +145,7 @@
   <doc cat="ses"   doc="ses-tuning"        branches="master ses6">Tuning Guide</doc>
   <doc cat="ses"   doc="ses-security"      branches="master">Security Hardening Guide</doc>
   <doc cat="ses"   doc="ses-rook"          branches="master">Deploying and Administrating Ceph on SUSE CaaS Platform</doc>
-  <doc cat="ses"   doc="ceph-windows"      branches="master">Ceph for Windows</doc>
+  <doc cat="ses"   doc="ses-windows"       branches="master">SUSE Enterprise Storage for Windows</doc>
 
   <doc cat="cap"   doc="cap-guides"        branches="master">Deployment, Administration, and User Guides</doc>
   <doc cat="cap-rn" doc="release-notes"    branches="master">Release Notes</doc>


### PR DESCRIPTION
Recently changed the name from Ceph for Windows to SES for Windows - this change reflects that. 