### PR TITLE
Add release notes

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -68,6 +68,7 @@
     <cat id="soc"        repo="doc-cloud">SUSE OpenStack Cloud</cat>
     <cat id="pubcloud"   repo="doc-public-cloud">SUSE Public Cloud</cat>
     <cat id="styleguide" repo="doc-styleguide">SUSE Documentation Style Guide</cat>
+    <cat id="release-notes" repo="release-notes">Release Notes</cat>
   </cats>
 
   <redirect from="caasp-5-rn" to="caasp-release-notes/master/html/release-notes/"/>
@@ -261,5 +262,8 @@
 
   <doc cat="styleguide" doc="docu_styleguide" branches="main">Style Guide</doc>
   <doc cat="styleguide" doc="docu_styleguide_with_changes" branches="main">Style Guide with Change Log</doc>
+
+  <doc cat="release-notes" doc="sles" branches="15_SP4 15_SP3">SUSE Linux Enterprise Server</doc>
+  <doc cat="release-notes" doc="sled" branches="15_SP4 15_SP3">SUSE Linux Enterprise Desktop</doc>
 
 </indexconfig>

--- a/config.xml
+++ b/config.xml
@@ -263,7 +263,7 @@
   <doc cat="styleguide" doc="docu_styleguide" branches="main">Style Guide</doc>
   <doc cat="styleguide" doc="docu_styleguide_with_changes" branches="main">Style Guide with Change Log</doc>
 
-  <doc cat="release-notes" doc="sles" branches="15_SP4 15_SP3">SUSE Linux Enterprise Server</doc>
-  <doc cat="release-notes" doc="sled" branches="15_SP4 15_SP3">SUSE Linux Enterprise Desktop</doc>
+  <doc cat="release-notes" doc="release-notes" branches="sles-15_SP4 sles-15_SP3">SUSE Linux Enterprise Server</doc>
+  <doc cat="release-notes" doc="release-notes" branches="sled-15_SP4 sled-15_SP3">SUSE Linux Enterprise Desktop</doc>
 
 </indexconfig>

--- a/config.xml
+++ b/config.xml
@@ -263,7 +263,7 @@
   <doc cat="styleguide" doc="docu_styleguide" branches="main">Style Guide</doc>
   <doc cat="styleguide" doc="docu_styleguide_with_changes" branches="main">Style Guide with Change Log</doc>
 
-  <doc cat="release-notes" doc="release-notes" branches="sles-15_SP4 sles-15_SP3">SUSE Linux Enterprise Server</doc>
-  <doc cat="release-notes" doc="release-notes" branches="sled-15_SP4 sled-15_SP3">SUSE Linux Enterprise Desktop</doc>
+  <doc cat="release-notes" doc="release-notes" branches="sles-15_SP4">SUSE Linux Enterprise Server</doc>
+  <doc cat="release-notes" doc="release-notes" branches="sled-15_SP4">SUSE Linux Enterprise Desktop</doc>
 
 </indexconfig>


### PR DESCRIPTION
So I've tried two ways of adding the RN entries to the `config.xml`:

1. With their respective product
2. Separately


1) doesn't work AFAIU because release notes are not a document that is part of the same repository. The generated URL then also doesn't match. HOWEVER, if there is ever a time when release notes become just another part of their respective documentation repo, this would work.
2) This works but the URL has to be changed because with each RN type being a separate `doc`, the URL is actually `susedoc.github.io/release-notes/15_SP4/html/sled/` instead of `susedoc.github.io/release-notes/sled-15_SP4/html`.

Maybe I missed something so please let me know if you think there's a better way of doing things! I suppose we could also consider a separate HTML page with just release notes that would not be tied to the current structure but I'd rather not duplicate work like that.