### PR TITLE
Add container guide to doc-unversioned

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -109,7 +109,7 @@
   <doc cat="sles"  doc="SLES-xen2kvmquick" branches="SLE15SP2 SLE15SP1 SLE15SP0 SLE12SP5 SLE12SP4">Xen to KVM Migration Guide</doc>
   <doc cat="sles"  doc="SLES-jeos"         branches="SLE15SP3 SLE15SP2">JeOS Guide</doc>
   <doc cat="sles"  doc="SLES-minimal-vm"   branches="main SLE15SP4">Minimal VM Quick Start Guide</doc>
-  <doc cat="sles"  doc="SLES-container"    branches="main SLE15SP4 SLE15SP3 SLE15SP2">Container Guide</doc>
+  <doc cat="sles"  doc="SLES-container"    branches="SLE15SP4 SLE15SP3 SLE15SP2">Container Guide</doc>
 
 
   <doc cat="sle-micro" doc="SLE-Micro-deployment" branches="main SLE_Micro_5.1 SLE_Micro_5.2">Deployment Guide</doc>
@@ -273,4 +273,5 @@
 
   <!-- Unversioned -->
   <doc cat="unvers" doc="SLES-pci-dss" branches="main">Payment Card Industry Data Security Standard (PCI DSS) Guide</doc>
+  <doc cat="unvers" doc="SLE-container-guide" branches="main">SUSE Linux Enterprise Containers</doc>
 </indexconfig>


### PR DESCRIPTION
* Remove main from Container Guide (the latest version will be built from doc-unversioned
* Add new entry for doc-unversioned

Related info:
* SUSE/doc-sle#1339