### PR TITLE
Fix Liberty 7 and 8 branches

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -271,8 +271,8 @@
   <doc cat="release-notes" doc="release-notes" branches="sle-hpc-15_SP4 sle-hpc-15_SP5" formats="html">SUSE Linux Enterprise High Performance Computing</doc>
 
   <doc cat="liberty" doc="quickstart" branches="main">Registering RHEL 9</doc>
-  <doc cat="liberty" doc="quickstart" branches="maintenance/SLL8">Registering RHEL 8 or CentOS Linux 8</doc>
-  <doc cat="liberty" doc="quickstart" branches="maintenance/SLL7">Registering RHEL 7 or CentOS Linux 7</doc>
+  <doc cat="liberty" doc="quickstart" branches="SLL8">Registering RHEL 8 or CentOS Linux 8</doc>
+  <doc cat="liberty" doc="quickstart" branches="SLL7">Registering RHEL 7 or CentOS Linux 7</doc>
 
   <!-- Unversioned -->
   <doc cat="unvers" doc="pcidss/SLES-pci-dss" outputname="SLES-pci-dss" branches="main">Payment Card Industry Data Security Standard (PCI DSS) Guide</doc>


### PR DESCRIPTION
Noticed that I didn't need to have the `maintenance/` part of the branch name, so that's now removed.