### PR TITLE
removes the redundant poc systemd concept

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -232,7 +232,6 @@
   <doc cat="smartdocs" doc="minimal-vm" branches="main">Introduction to SLES Minimal VM</doc>
   <doc cat="smartdocs" doc="concept-klp" branches="main">Kernel Live Patching Concept</doc>
   <doc cat="smartdocs" doc="concept-manage-virtual-machines-libvirt" branches="main">Managing virtual machines with libvirt: Basic Concept</doc>
-  <doc cat="smartdocs" doc="concept-systemd" branches="main">Basic systemd Concepts</doc>
   <doc cat="smartdocs" doc="ntp-time-synchronization" branches="main">Time synchronization using NTP</doc>
   <doc cat="smartdocs" doc="concept-virtual-disk-cache-modes" branches="main">Virtual disk cache: Basic concept</doc>
   <doc cat="smartdocs" doc="concept-virtualization" branches="main">Virtualization: Basic concept</doc>
@@ -264,7 +263,7 @@
   <doc cat="smartdocs" doc="systemd-basics" branches="main">systemd basics</doc>
   <doc cat="smartdocs" doc="subnet-manager-configuring" branches="main">Configuring a Subnet Manager</doc>
   <doc cat="smartdocs" doc="elemental" branches="main">Elemental teal</doc>
-  
+
 <!-- ALP -->
   <doc cat="alp" doc="alp-dolomite" branches="main">The SUSE ALP Dolomite Guide</doc>
   <doc cat="alp" doc="cockpit-alp-dolomite" branches="main">The SUSE ALP Dolomite Cockpit Guide</doc>
@@ -275,7 +274,7 @@
   <doc cat="smartdocs" doc="cockpit-slemicro" branches="main">The SLE Micro Cockpit Guide</doc>
   <doc cat="smartdocs" doc="SLE-Micro-admin" branches="main">The SLE Micro Admin Guide</doc>
   <doc cat="smartdocs" doc="cockpit-slemicro" branches="main">Cockpit Guide</doc>
-  
+
   <!-- Real documents from assemblies -->
   <doc cat="smartdocs" doc="systemd-working-with-timers" branches="main">Working with systemd timers</doc>
 


### PR DESCRIPTION
To remove the redundant poc
https://documentation.suse.com/smart/systems-management/html/concept-systemd/index.html#:~:text=systemd%20provides%20a%20number%20of,when%20there%20is%20no%20demand.