### PR TITLE
Fix typo in config.xml

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -94,7 +94,7 @@
   <doc cat="sles16"  doc="SLES-x86-64-agama-based-installation" branches="main">Installing SLE16 for x86-64 using Agama</doc>
   <doc cat="sles16"  doc="SLES-snapper-basics" branches="main">Snapper basics</doc>
   <doc cat="sles16"  doc="SLES-copy-file-rsync" branches="main">Copying Files and Directories with rsync</doc>
-  <doc cat="sles16"  doc="SLE-os-identification" branches="main">SLE OS indetification</doc>
+  <doc cat="sles16"  doc="SLE-os-identification" branches="main">SLE OS identification</doc>
   <doc cat="sles16"  doc="SLES-SELinux" branches="main">Understanding SELinux Basics</doc>
    <doc cat="sles16" doc="SLES-systemd-timers" branches="main">Working with Systemd Timers</doc>
   <doc cat="sles16"  doc="SLES-ntp-time-synchronization" branches="main">Synchronizing Time Using NTP/NTS</doc>


### PR DESCRIPTION
Fix typo in name of "SLE OS identification"