### PR TITLE
Add HA introduction article

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -113,7 +113,8 @@
   <doc cat="sles16"  doc="SLES-valkey" branches="main">Introduction to Valkey</doc>
   <doc cat="sles16"  doc="SLES-virtualization" branches="main">Virtualization</doc>
   <doc cat="sles16"  doc="HA-installing-two-node-cluster" branches="main">Installing a Basic Two-Node High Availability Cluster</doc>
-  <doc cat="sles16"  doc="HA-installing-three-node-cluster" branches="main">Installing a Basic Three-Node High Availability Cluster</doc> 
+  <doc cat="sles16"  doc="HA-installing-three-node-cluster" branches="main">Installing a Basic Three-Node High Availability Cluster</doc>
+  <doc cat="sles16"  doc="HA-introduction" branches="main">Introduction to SUSE Linux Enterprise High Availability</doc>
   <doc cat="sles16"  doc="SLES-systemd-securing" branches="main">Securing systemd services</doc>
   <doc cat="sles16"  doc="SLE-differences-faq" branches="main">Differences between SLE 15 and SLE 16 FAQ</doc>
   


### PR DESCRIPTION
The other changed line for `HA-installing-three-node-cluster` is probably deleted white space. 